### PR TITLE
Return the levels as part of the main table

### DIFF
--- a/logroll/init.lua
+++ b/logroll/init.lua
@@ -14,6 +14,7 @@ local LOG_LEVELS = {'DEBUG', 'INFO', 'WARN', 'ERROR'}
 for i, label in ipairs(LOG_LEVELS) do
     logroll[label] = i
 end
+logroll.levels = LOG_LEVELS
 
 
 local function default_formatter(level, ...)


### PR DESCRIPTION
This allows for user-specified formatters to use those levels, the same way
that default_formatter() does. Developped jointly with
@koraykv
